### PR TITLE
FIX: fetch remote - Github was missing another "/" to clone the phh git

### DIFF
--- a/twrp-extras.xml
+++ b/twrp-extras.xml
@@ -9,7 +9,7 @@
             review="https://review.lineageos.org"/>
 
     <remote name="github"
-            fetch="https:/github.com"/>
+            fetch="https://github.com"/>
 
     <project path="build/soong" name="android_build_soong" remote="TeamWin" revision="android-11">
         <linkfile src="root.bp" dest="Android.bp"/>


### PR DESCRIPTION
I noticed that the remote for github was missing a `/` after receiving an error from my github actions of an invalid url, so this tiny patch should fix it